### PR TITLE
Add option to azure login action with service principals and `az acr login` in`twostep-container-build`

### DIFF
--- a/.github/workflows/test-twostep-container-build.yml
+++ b/.github/workflows/test-twostep-container-build.yml
@@ -127,4 +127,33 @@ jobs:
             echo "This was supposed to use the cache version"
             exit 1
           fi
-    
+
+  test-azure-cr:
+    runs-on: cfa-cdcgov
+    name: Build and push image
+    steps:
+      - name: Login to Azure
+        id: azure_login_2
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZ_SERVICE_PRINCIPAL_CREDS_STRING }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ vars.AZ_CONTAINER_REGISTRY_NAME }}
+        
+      - name: Build and push image
+        id: build-push
+        uses: CDCgov/cfa-actions/twostep-container-build@v1.2.0
+        with:
+          container-file-1: twostep-container-build/examples/Containerfile.dependencies
+          container-file-2: twostep-container-build/examples/Containerfile
+          first-step-cache-key: with-args-${{ hashFiles('twostep-container-build/examples/Containerfile.dependencies') }}
+          image: cdcgov/_cfa-actions-test
+          build-args-2: |
+            GH_SHA=${{ github.sha }}
+          push-image-1: true
+          push-image-2: true
+      - name: Clean up by deleting image
+        id: delete-images
+        run: az acr repository delete --name {{ vars.AZ_CONTAINER_REGISTRY_NAME }} --repository cdcgov/_cfa-actions-test
+        

--- a/twostep-container-build/README.md
+++ b/twostep-container-build/README.md
@@ -100,6 +100,7 @@ jobs:
           container-file-2: ./Containerfile
           first-step-cache-key: docker-dependencies-${{ runner.os }}-${{ hashFiles('./Containerfile.dependencies') }}
           image: ${{ env.IMAGE_NAME }}
+          registry: $${ env.CONTAINER_REGISTRY_NAME }}.azurecr.io/
           build-args-2: |
             TAG=${{ steps.image.outputs.tag }}
             GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}

--- a/twostep-container-build/README.md
+++ b/twostep-container-build/README.md
@@ -34,9 +34,9 @@ Caching is done by storing the cache-key as a label in the image (`TWO_STEP_BUIL
 | `container-file-2` | Path to the second container file | true | |
 | `first-step-cache-key` | Cache key for the first step | true | |
 | `image` | Name of the image | true | |
-| `username` | Username for the registry | true |  |
-| `password` | Password for the registry | true |  |
-| `registry` | Registry to push the image to | true |  |
+| `username` | Username for the registry | false |  |
+| `password` | Password for the registry | false |  |
+| `registry` | Registry to push the image to | false |  |
 | `main-branch-name` | Name of the main branch | false | `'main'` |
 | `main-branch-tag` | Tag to use for the main branch | false | `'latest'` |
 
@@ -59,6 +59,52 @@ The action has the following outputs:
 | `branch` | Branch name |
 | `summary` | A summary of the action: (`built`, `re-built`, or `cached`) |
 
+
+## Example: using the Azure container registry
+It is possible to log in by providing an explicit azure container registry username and password, but for CFA use we recommend a service principal-mediated login approach on a self-hosted runner. Here is an example, based on a [real workflow](https://github.com/CDCgov/pyrenew-hew/blob/main/.github/workflows/containers.yaml) from the [`pyrenew-hew`](https://github.com/cdcgov/pyrenew-hew) repo. You'll first need to create a valid [creds string](https://github.com/Azure/login?tab=readme-ov-file#creds) for your Azure Service Principal and store it as a repo secret. In this example, we've named the secret `MY_SERVICE_PRINCIPAL_CREDS_STRING`.
+
+```yaml
+name: Create Docker Image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: example-image-name
+  CONTAINER_REGISTRY_NAME: myacrregistry
+
+jobs:
+
+  build-and-push-image:
+    runs-on: cfa-cdcgov
+    name: Build and push image
+
+    steps:
+      - name: Login to Azure
+        id: azure_login_2
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.MY_SERVICE_PRINCIPAL_CREDS_STRING }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ env.CONTAINER_REGISTRY_NAME }}
+        
+      - name: Build and push image
+        id: build-push
+        uses: CDCgov/cfa-actions/twostep-container-build@v1.2.0
+        with:
+          container-file-1: ./Containerfile.dependencies
+          container-file-2: ./Containerfile
+          first-step-cache-key: docker-dependencies-${{ runner.os }}-${{ hashFiles('./Containerfile.dependencies') }}
+          image: ${{ env.IMAGE_NAME }}
+          build-args-2: |
+            TAG=${{ steps.image.outputs.tag }}
+            GIT_COMMIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
+            GIT_BRANCH_NAME=${{ steps.branch.outputs.name }}
+```
 
 ## Example: Using ghcr.io
 

--- a/twostep-container-build/README.md
+++ b/twostep-container-build/README.md
@@ -34,9 +34,9 @@ Caching is done by storing the cache-key as a label in the image (`TWO_STEP_BUIL
 | `container-file-2` | Path to the second container file | true | |
 | `first-step-cache-key` | Cache key for the first step | true | |
 | `image` | Name of the image | true | |
+| `registry` | Registry to push the image to | true |  |
 | `username` | Username for the registry | false |  |
 | `password` | Password for the registry | false |  |
-| `registry` | Registry to push the image to | false |  |
 | `main-branch-name` | Name of the main branch | false | `'main'` |
 | `main-branch-tag` | Tag to use for the main branch | false | `'latest'` |
 

--- a/twostep-container-build/README.md
+++ b/twostep-container-build/README.md
@@ -94,7 +94,7 @@ jobs:
         
       - name: Build and push image
         id: build-push
-        uses: CDCgov/cfa-actions/twostep-container-build@v1.2.0
+        uses: CDCgov/cfa-actions/twostep-container-build@v1.2.1
         with:
           container-file-1: ./Containerfile.dependencies
           container-file-2: ./Containerfile

--- a/twostep-container-build/action.yml
+++ b/twostep-container-build/action.yml
@@ -47,7 +47,6 @@ inputs:
       with trailing slash. For example, ghcr.io/,
       cfaprodbatchcr.azurecr.io/, etc.
     required: true
-    default: ''
   main-branch-name:
     description: |
       The name of the repository's base branch. Defaults to main.

--- a/twostep-container-build/action.yml
+++ b/twostep-container-build/action.yml
@@ -26,29 +26,27 @@ inputs:
     required: true
   username:
     description: |
-      The username to use for the container registry login. If this, 
-      'registry', and 'password' are all provided, the action will attempt to
-      use docker/login-action to log in to the specified registry. Otherwise, it 
-      will assume that user has handled authentication upstream.
+      The username to use for the container registry login. If this and 'password' 
+      are provided, the action will attempt to use docker/login-action to log in 
+      to the specified registry. Otherwise, it will assume that user has handled 
+      authentication upstream.
     required: false
     default: ''
   password:
     description: |
-      The password to use for the container registry login. If this, 'registry', 
-      and 'username' are all provided, the action will attempt to
-      use docker/login-action to log in to the specified registry. Otherwise, it 
-      will assume that user has handled authentication upstream.
+      The password to use for the container registry login. If this
+      and 'username' are provided, the action will attempt to
+      use docker/login-action to log in to the specified registry.
+      Otherwise, it will assume that user has handled authentication 
+      upstream.
     required: false
     default: ''
   registry:
     description: |
       The registry to use for the container registry login
       with trailing slash. For example, ghcr.io/,
-      cfaprodbatchcr.azurecr.io/, etc. If this, 'password', and 
-      'username' are all provided, the action will attempt to
-      use docker/login-action to log in to the specified registry. 
-      Otherwise, it will assume that user has handled authentication upstream.
-    required: false
+      cfaprodbatchcr.azurecr.io/, etc.
+    required: true
     default: ''
   main-branch-name:
     description: |
@@ -165,7 +163,7 @@ runs:
         fi
 
     - name: Login to the Container Registry
-      if: inputs.registry != '' && inputs.username != '' && inputs.password != ''
+      if: inputs.username != '' && inputs.password != ''
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}

--- a/twostep-container-build/action.yml
+++ b/twostep-container-build/action.yml
@@ -27,17 +27,20 @@ inputs:
   username:
     description: |
       The username to use for the container registry login.
-    required: true
+    required: false
+    default: ''
   password:
     description: |
       The password to use for the container registry login.
-    required: true
+    required: false
+    default: ''
   registry:
     description: |
       The registry to use for the container registry login
       with trailing slash. For example, ghcr.io/,
       cfaprodbatchcr.azurecr.io/, etc.
-    required: true
+    required: false
+    default: ''
   main-branch-name:
     description: |
       The name of the repository's base branch. Defaults to main.
@@ -153,7 +156,7 @@ runs:
         fi
 
     - name: Login to the Container Registry
-      if: inputs.registry != ''
+      if: inputs.registry != '' & inputs.username != '' & inputs.password != '':
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}

--- a/twostep-container-build/action.yml
+++ b/twostep-container-build/action.yml
@@ -26,19 +26,28 @@ inputs:
     required: true
   username:
     description: |
-      The username to use for the container registry login.
+      The username to use for the container registry login. If this, 
+      'registry', and 'password' are all provided, the action will attempt to
+      use docker/login-action to log in to the specified registry. Otherwise, it 
+      will assume that user has handled authentication upstream.
     required: false
     default: ''
   password:
     description: |
-      The password to use for the container registry login.
+      The password to use for the container registry login. If this, 'registry', 
+      and 'username' are all provided, the action will attempt to
+      use docker/login-action to log in to the specified registry. Otherwise, it 
+      will assume that user has handled authentication upstream.
     required: false
     default: ''
   registry:
     description: |
       The registry to use for the container registry login
       with trailing slash. For example, ghcr.io/,
-      cfaprodbatchcr.azurecr.io/, etc.
+      cfaprodbatchcr.azurecr.io/, etc. If this, 'password', and 
+      'username' are all provided, the action will attempt to
+      use docker/login-action to log in to the specified registry. 
+      Otherwise, it will assume that user has handled authentication upstream.
     required: false
     default: ''
   main-branch-name:
@@ -156,7 +165,7 @@ runs:
         fi
 
     - name: Login to the Container Registry
-      if: inputs.registry != '' & inputs.username != '' & inputs.password != ''
+      if: inputs.registry != '' && inputs.username != '' && inputs.password != ''
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}

--- a/twostep-container-build/action.yml
+++ b/twostep-container-build/action.yml
@@ -156,7 +156,7 @@ runs:
         fi
 
     - name: Login to the Container Registry
-      if: inputs.registry != '' & inputs.username != '' & inputs.password != '':
+      if: inputs.registry != '' & inputs.username != '' & inputs.password != ''
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}


### PR DESCRIPTION
This should be a more robust approach. It should be more secure and should also help with https://github.com/CDCgov/pyrenew-hew/issues/321

Also makes the docker login action inputs optional, since they are only needed and used if you go that route. I also see some argument that the action shouldn't attempt to log in at all, and the user should handle that upstream in their workflow.