### PR TITLE
Add format-r-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repo contains personalized actions designed by CDC's CFA team. Please use w
 - [post-artifact](./post-artifact): Post an artifact as a comment in a PR. Useful when you need to easily access a built element during a workflow such as a website, a report, etc.
 - [twostep-container-build](./twostep-container-build): Cache dependencies of a project by splitting the build process in two steps. The first step builds the dependencies and caches the image. The second step builds the project using the cached image as a base.
 - [runner-action](./runner-action): Run a bash script on an Azure Container App runner in the Azure Ext subscription
-  
+- [format-r-code](./format-r-code): Format R code with the [air](https://posit-dev.github.io/air) formatter from Posit.
+
 
 ## Public Domain Standard Notice
 This repository constitutes a work of the United States Government and is not
@@ -69,4 +70,4 @@ published through the [CDC web site](http://www.cdc.gov).
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template) for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/main/CONTRIBUTING.md), [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/main/DISCLAIMER.md), and [code of conduct](https://github.com/CDCgov/template/blob/main/code-of-conduct.md).
 
 > [!IMPORTANT]
-**General disclaimer** This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise. 
+**General disclaimer** This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/organization/mission.htm).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise.

--- a/format-r-code/README.md
+++ b/format-r-code/README.md
@@ -1,6 +1,7 @@
 # format-r-code
 
 ## Format R code with air
+This action is copied from the [rstudio/shiny-workflows](https://github.com/rstudio/shiny-workflows/tree/7efb26e82a6b58deef846d8e3abef7eb0a533038/format-r-code) repository.
 
 This GitHub Action automatically formats R code using the [air formatter](https://posit-dev.github.io/air), a new, blazing-fast R code formatter from [Posit](https://posit.co).
 

--- a/format-r-code/README.md
+++ b/format-r-code/README.md
@@ -1,0 +1,62 @@
+# format-r-code
+
+## Format R code with air
+
+This GitHub Action automatically formats R code using the [air formatter](https://posit-dev.github.io/air), a new, blazing-fast R code formatter from [Posit](https://posit.co).
+
+This action installs the `air` formatter and uses it to format R code in your repository. It can either check if the code is properly formatted or automatically format the code and commit the changes.
+
+## Inputs
+
+| Input   | Description                                      | Default   | Required |
+| ------- | ------------------------------------------------ | --------- | -------- |
+| version | Version of air to use (e.g., `0.1.2`)            | `latest`  | No       |
+| check   | If `'true'`, only check that R code is formatted | `'false'` | No       |
+| path    | Path(s) to check (space-separated string)        | `'.'`     | No       |
+
+## Usage
+
+To use this action in your workflow, add the following step:
+
+```yaml
+- name: Format R code
+  uses: CDCgov/cfa-actions/format-r-code@v1
+```
+
+By default, `format-r-code` formats all R code in the repository. You can configure which directories or files are formatted with the `path` option. For example, the following formats only R files in the `R/` directory and the `app.R` file in the `my-example` Shiny app.
+
+```yaml
+- name: Format R code
+  uses: CDCgov/cfa-actions/format-r-code@v1
+  with:
+    path: R/ inst/examples-shiny/my-example/app.R
+```
+
+`format-r-code` commits all changes back to the repository, so be sure to configure your git user in the worflow:
+
+```yaml
+- name: Commit changes
+  run: |
+    git config --global user.name "$GITHUB_ACTOR"
+    git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+- name: Format R code
+  uses: CDCgov/cfa-actions/format-r-code@v1
+```
+
+On the other hand, if you'd rather check that the R code is already formatted as expected or have the workflow fail, set `check: true`:
+
+```yaml
+- name: Format R code
+  uses: CDCgov/cfa-actions/format-r-code@v1
+  with:
+    check: true
+```
+
+## Configuring air
+
+The best way to configure `air` for your personal style needs is to use an `air.toml` file in your repository. Read more about [configuring air on the air website](https://posit-dev.github.io/air/configuration.html).
+
+## License
+
+The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/format-r-code/README.md
+++ b/format-r-code/README.md
@@ -20,14 +20,14 @@ To use this action in your workflow, add the following step:
 
 ```yaml
 - name: Format R code
-  uses: CDCgov/cfa-actions/format-r-code@v1
+  uses: CDCgov/cfa-actions/format-r-code@v1.4.0
 ```
 
 By default, `format-r-code` formats all R code in the repository. You can configure which directories or files are formatted with the `path` option. For example, the following formats only R files in the `R/` directory and the `app.R` file in the `my-example` Shiny app.
 
 ```yaml
 - name: Format R code
-  uses: CDCgov/cfa-actions/format-r-code@v1
+  uses: CDCgov/cfa-actions/format-r-code@v1.4.0
   with:
     path: R/ inst/examples-shiny/my-example/app.R
 ```
@@ -41,14 +41,14 @@ By default, `format-r-code` formats all R code in the repository. You can config
     git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
 - name: Format R code
-  uses: CDCgov/cfa-actions/format-r-code@v1
+  uses: CDCgov/cfa-actions/format-r-code@v1.4.0
 ```
 
 On the other hand, if you'd rather check that the R code is already formatted as expected or have the workflow fail, set `check: true`:
 
 ```yaml
 - name: Format R code
-  uses: CDCgov/cfa-actions/format-r-code@v1
+  uses: CDCgov/cfa-actions/format-r-code@v1.4.0
   with:
     check: true
 ```

--- a/format-r-code/action.yaml
+++ b/format-r-code/action.yaml
@@ -1,0 +1,73 @@
+name: "Format R code with air"
+description: "Automatically format R code with air."
+author: "Damon Bayer, Garrick Aden-Buie"
+
+inputs:
+  version:
+    description: Version of air, e.g. `0.1.2`.
+    default: latest
+    required: false
+  check:
+    description: If `'true'`, only check that R code is formatted.
+    default: "false"
+    required: false
+  path:
+    description: Path(s) to check as a space-separate single string
+    default: "."
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install air (latest, Windows)
+      if: inputs.version == 'latest' && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        irm https://github.com/posit-dev/air/releases/latest/download/air-installer.ps1 | iex
+
+    - name: Install air (version, Windows)
+      if: inputs.version != 'latest' && runner.os == 'Windows'
+      shell: powershell
+      run: |
+        irm https://github.com/posit-dev/air/releases/download/${{ inputs.version }}/air-installer.ps1 | iex
+
+    - name: Install air (latest, Mac/Linux)
+      if: inputs.version == 'latest' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
+
+    - name: Install air (version, Mac/Linux)
+      if: inputs.version != 'latest' && runner.os != 'Windows'
+      shell: bash
+      run: |
+        curl -LsSf https://github.com/posit-dev/air/releases/download/${{ inputs.version }}/air-installer.sh | sh
+
+    - name: air version
+      shell: bash
+      run: |
+        echo ""
+        echo "Formatting R code with $(air --version)"
+        echo ""
+
+    - name: Check R code formatting
+      if: inputs.check == 'true'
+      shell: bash
+      run: air format --check ${{ inputs.path }}
+
+    - name: Format R code
+      if: inputs.check != 'true'
+      shell: bash
+      run: air format ${{ inputs.path }}
+
+    - name: Commit changes
+      if: inputs.check != 'true'
+      shell: bash
+      run: |
+        if find . -type f \( -name '*.r' -o -name '*.R' \) -exec git add -u {} +; then
+          echo "Staged modified R files"
+        else
+          echo "No changes found in any R files"
+        fi
+
+        git commit -m '`air format` (GitHub Actions)' || echo "No format changes to commit"

--- a/runner-action/README.md
+++ b/runner-action/README.md
@@ -1,6 +1,6 @@
 # Runner Action
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > This action is intended for internal use. This action will not work if you use it in a repository outside of [CDCgov](https://github.com/CDCgov) or [CDCent](https://github.com/cdcent).
 
 This action allows you to securely run scripts on the Azure Container App runners in the Azure subscription from public runners. A Github App is required with 'read' permissions for Actions, Contents, and Metadata on the CDCEnt repo [cfa-cdcgov-actions](https://github.com/cdcent/cfa-cdcgov-actions).
@@ -38,15 +38,15 @@ The Container App runners have some limitations compared to `ubuntu-latest`, nam
 
 ## Inputs and Outputs
 
-| Field | Description | Required | Default |
-|-------|-------------|----------|---------|
-| `github_app_id` | A GitHub App ID installed on CDCEnt | true | |
-| `github_app_pem` | The PEM-encoded private key for the GitHub APP| true | |
-| `script` | A bash script to be run on the Azure self-hosted runner | true | |
-| `wait_for_completion` | true/false option to wait for the dispatched workflow to complete | false | false |
-| `print_logs` | true/false option to print the action logs once the workflow has completed | false | false |
-| `max_retries` | integer with max number of retries when using wait_for_completion or print_logs | false | 20 |
-| `retry_interval` | integer representing the number of seconds between retries | false | 15 |
+| Field                 | Description                                                                     | Required | Default |
+| --------------------- | ------------------------------------------------------------------------------- | -------- | ------- |
+| `github_app_id`       | A GitHub App ID installed on CDCEnt                                             | true     |         |
+| `github_app_pem`      | The PEM-encoded private key for the GitHub APP                                  | true     |         |
+| `script`              | A bash script to be run on the Azure self-hosted runner                         | true     |         |
+| `wait_for_completion` | true/false option to wait for the dispatched workflow to complete               | false    | false   |
+| `print_logs`          | true/false option to print the action logs once the workflow has completed      | false    | false   |
+| `max_retries`         | integer with max number of retries when using wait_for_completion or print_logs | false    | 20      |
+| `retry_interval`      | integer representing the number of seconds between retries                      | false    | 15      |
 
 ## Examples and Usage
 The script passed to this action is a normal bash script which means marketplace actions can't be used here.
@@ -59,7 +59,7 @@ The following example uses the `az acr import` command to pull an image from GHC
     runs-on: ubuntu-latest
     steps:
     - name: ACR Import
-      uses: CDCgov/cfa-actions/runner-action@1.3.0 # check cfa-actions repo for latest tag
+      uses: CDCgov/cfa-actions/runner-action@1.4.0 # check cfa-actions repo for latest tag
       with:
         github_app_id: ${{ secrets.CDCENT_ACTOR_APP_ID }}
         github_app_pem: ${{ secrets.CDCENT_ACTOR_APP_PEM }}
@@ -139,4 +139,4 @@ If you have existing scripts in your repository, you can access them by using `g
 
           chmod +x hello_world.sh
           ./hello_world.sh
-``` 
+```


### PR DESCRIPTION
Copied from https://github.com/rstudio/shiny-workflows/tree/main/format-r-code, which has a CC0 license and the following warning

> 🚩🚩🚩 This repo is intended for internal use only. Sweeping changes will be made without notice. 🚩🚩🚩
