### PR TITLE
Update runner-action.yml to change defaults and add uuid

### DIFF
--- a/runner-action/action.yml
+++ b/runner-action/action.yml
@@ -19,17 +19,17 @@ inputs:
       A bash script to be run on the Azure self-hosted runner
     required: true
   wait_for_completion:
-    description: true/false to wait for the dispatched workflow to complete
+    description: true/false to wait for the dispatched workflow to complete. Default=true
     required: false
-    default: false
+    default: true
   print_logs:
-    description: true/false to print the action logs once the workflow has completed
+    description: true/false to print the action logs once the workflow has completed. Default=true
     required: false
-    default: false
+    default: true
   max_retries:
-    description: integer with max number of retries when using wait_for_completion or print_logs. Default=20
+    description: integer with max number of retries when using wait_for_completion or print_logs. Default=120
     required: false
-    default: 20
+    default: 120
   retry_interval:
     description: integer representing the number of seconds between retries. Default=15
     required: false
@@ -59,7 +59,7 @@ runs:
       shell: bash
       id: unique-run-name
       run: |
-        echo "name=${{ github.repository_owner }}_${{ github.event.repository.name }}_${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+        echo "name=${{ github.repository_owner }}_${{ github.event.repository.name }}_${{ github.run_id }}_$(uuidgen)" >> "$GITHUB_OUTPUT"
 
     - name: Encrypt Script
       shell: bash


### PR DESCRIPTION
- Changed the defaults to be more in-line with all the usage we have seen so far
- Introduced a uuid to make the run id unique and support multiple runner-action uses within a single workflow

Confirmed to be working on matrix jobs here: https://github.com/CDCgov/cfa-epinow2-pipeline/actions/runs/16946275587
Runs containing UUIDs can be seen in the cdcent/cfa-cdcgov-actions repo:
<img width="658" height="252" alt="image" src="https://github.com/user-attachments/assets/3e9893f6-767e-477e-b23e-22ebd9f4dc6a" />
